### PR TITLE
Merkeliste save-button and Contacts + Imprint styling for mobile

### DIFF
--- a/src/components/general/ProjectSingle.svelte
+++ b/src/components/general/ProjectSingle.svelte
@@ -113,7 +113,26 @@
 		</div>
 
 		<div class="description-container">
-			<h1 class="title">{getLocalizedLabel(project.title, $activeLanguage)}</h1>
+			<div class="description-title-container">
+				<h1 class="title">{getLocalizedLabel(project.title, $activeLanguage)}</h1>
+				<button
+					class="save-button"
+					class:saved={isSaved}
+					on:click={handleSaveClick}
+					aria-label={isSaved
+						? getUIText('merkliste.removeFromMerkliste', $activeLanguage)
+						: getUIText('merkliste.addToMerkliste', $activeLanguage)}
+					data-tooltip={isSaved
+						? getUIText('merkliste.removeFromMerkliste', $activeLanguage)
+						: getUIText('merkliste.addToMerkliste', $activeLanguage)}
+				>
+					{#if isSaved}
+						<img src="{base}/icons/basket_full.png" alt="Remove" class="basket-icon" />
+					{:else}
+						<img src="{base}/icons/basket_empty.png" alt="Add" class="basket-icon" />
+					{/if}
+				</button>
+			</div>
 			<p class="author">{project.author}</p>
 			{#if project.coauthors && project.coauthors.length > 0}
 				<div class="coauthors">
@@ -122,7 +141,7 @@
 					{/each}
 				</div>
 			{/if}
-			<br />
+			<!-- <br /> -->
 			<div class="location-format-section">
 				<p class="category">
 					{project.formats.map((format) => getLocalizedLabel(format, $activeLanguage)).join(', ')}
@@ -214,6 +233,12 @@
 			grid-row: 3 / 4;
 			transform: rotate(0deg);
 		}
+	}
+
+	.description-title-container {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
 	}
 
 	.title-image-container {
@@ -319,8 +344,7 @@
 		transition: all 200ms ease-in-out;
 		z-index: 20;
 		display: flex;
-		align-items: center;
-		justify-content: center;
+		align-self: flex-start;
 		gap: 0.5rem;
 		white-space: nowrap;
 		flex-shrink: 0;

--- a/src/components/general/ProjectSingle.svelte
+++ b/src/components/general/ProjectSingle.svelte
@@ -397,8 +397,8 @@
 			transition: opacity 200ms ease-in-out;
 			z-index: 30;
 			pointer-events: none;
-			opacity: 0;
-			visibility: hidden;
+			// opacity: 0;
+			// visibility: hidden;
 		}
 
 		&:hover::before {
@@ -440,9 +440,9 @@
 				height: 2.5rem;
 			}
 
-			&:hover::before {
-				opacity: 0;
-				visibility: hidden;
+			&::before {
+				transform: translate(-110%, 20%);
+				font-size: 0.75rem;
 			}
 		}
 	}

--- a/src/components/general/ProjectSingle.svelte
+++ b/src/components/general/ProjectSingle.svelte
@@ -441,7 +441,7 @@
 			}
 
 			&::before {
-				transform: translate(-110%, 20%);
+				transform: translate(-105%, 20%);
 				font-size: 0.75rem;
 			}
 		}

--- a/src/components/general/ProjectSingle.svelte
+++ b/src/components/general/ProjectSingle.svelte
@@ -397,8 +397,8 @@
 			transition: opacity 200ms ease-in-out;
 			z-index: 30;
 			pointer-events: none;
-			// opacity: 0;
-			// visibility: hidden;
+			opacity: 0;
+			visibility: hidden;
 		}
 
 		&:hover::before {

--- a/src/components/general/ProjectSingle.svelte
+++ b/src/components/general/ProjectSingle.svelte
@@ -382,6 +382,29 @@
 			font-size: $font-small;
 			white-space: nowrap;
 		}
+
+		// Tooltip on hover
+		&::before {
+			content: attr(data-tooltip);
+			position: absolute;
+			transform: translate(-110%, 25%);
+			background: rgba(0, 0, 0, 0.9);
+			color: white;
+			padding: 0.5rem 0.5rem;
+			border-radius: $border-radius;
+			font-size: 1rem;
+			white-space: nowrap;
+			transition: opacity 200ms ease-in-out;
+			z-index: 30;
+			pointer-events: none;
+			opacity: 0;
+			visibility: hidden;
+		}
+
+		&:hover::before {
+			opacity: 1;
+			visibility: visible;
+		}
 	}
 
 	@include mobile-and-tablet {
@@ -415,6 +438,11 @@
 			.basket-icon {
 				width: 2.5rem;
 				height: 2.5rem;
+			}
+
+			&:hover::before {
+				opacity: 0;
+				visibility: hidden;
 			}
 		}
 	}

--- a/src/components/general/overlay/PaperContainer.svelte
+++ b/src/components/general/overlay/PaperContainer.svelte
@@ -3,6 +3,7 @@
 
 	export let staticRotation: number | undefined = undefined;
 	export let padding: string = '2rem';
+	export let paddingLeft: string = '5rem';
 	export let width: string = 'auto';
 	export let height: string = 'auto';
 	export let vertical: 'top' | 'bottom' = 'top';
@@ -16,7 +17,7 @@
 	class:top={vertical === 'top'}
 	class:bottom={vertical === 'bottom'}
 	class:fixed
-	style="--rotation: {rotation}deg; --padding: {padding}; --width: {width}; --height: {height};"
+	style="--rotation: {rotation}deg; --padding: {padding}; --padding-left: {paddingLeft}; --width: {width}; --height: {height};"
 >
 	<slot />
 </div>
@@ -28,7 +29,7 @@
 		border-radius: $border-radius;
 		box-shadow: $paper-shadow-large;
 		padding: var(--padding);
-		padding-left: 5rem;
+		padding-left: var(--padding-left);
 		margin-left: -5rem;
 		height: var(--height);
 		position: relative;
@@ -36,9 +37,12 @@
 		bottom: -1rem;
 		display: flex;
 		justify-content: center;
-		align-items: center;
+		align-items: flex-start;
 		transform: rotate(var(--rotation));
-		transition: transform 0.3s ease, width 0.3s ease, height 0.3s ease;
+		transition:
+			transform 0.3s ease,
+			width 0.3s ease,
+			height 0.3s ease;
 		width: auto;
 
 		&.fixed {

--- a/src/routes/contacts/+page.svelte
+++ b/src/routes/contacts/+page.svelte
@@ -76,7 +76,7 @@
 </svelte:head>
 
 <main>
-	<PaperContainer fixed={false}>
+	<PaperContainer fixed={false} staticRotation={-1} paddingLeft="6.5rem">
 		<div class="content-container">
 			<h1>{@html contentData.heading}</h1>
 			<div class="content-text">

--- a/src/routes/imprint/+page.svelte
+++ b/src/routes/imprint/+page.svelte
@@ -76,7 +76,7 @@
 </svelte:head>
 
 <main>
-	<PaperContainer fixed={false}>
+	<PaperContainer fixed={false} staticRotation={1} paddingLeft="6rem">
 		<div class="content-container">
 			<h1>{@html contentData.heading}</h1>
 			<div class="content-text">


### PR DESCRIPTION
### Changes to `ProjectSingle.svelte`:

* Added a "save" button next to the project title with tooltips that display localized messages

### Updates to `PaperContainer.svelte`:

* Added a new `paddingLeft` property to allow more precise control over left padding, replacing the hardcoded value with a customizable CSS variable. [[1]](diffhunk://#diff-3a97f186fbcee319efa3ad720e110bb547809c29945d019e59d38754e899905dR6) [[2]](diffhunk://#diff-3a97f186fbcee319efa3ad720e110bb547809c29945d019e59d38754e899905dL19-R20) [[3]](diffhunk://#diff-3a97f186fbcee319efa3ad720e110bb547809c29945d019e59d38754e899905dL31-R45)

* Updated the `PaperContainer` usage in `contacts/+page.svelte` and `imprint/+page.svelte` to specify `staticRotation` and `paddingLeft` values for more refined layout control. [[1]](diffhunk://#diff-47ead1b786889619ec3796b09f6a414d1468047809c5d7aa92b8d573a7e2867aL79-R79) [[2]](diffhunk://#diff-c0947877700dd211793636719aa13b44fc5322f62e2c9814308cff8970f75a8dL79-R79)