### PR TITLE
Location contexts

### DIFF
--- a/src/components/general/accordion/AccordionList.svelte
+++ b/src/components/general/accordion/AccordionList.svelte
@@ -49,5 +49,6 @@
 		display: flex;
 		flex-direction: column;
 		width: 100%;
+		gap: 0.25em;
 	}
 </style>

--- a/src/components/general/overlay/PaperContainer.svelte
+++ b/src/components/general/overlay/PaperContainer.svelte
@@ -25,6 +25,10 @@
 <style lang="scss">
 	.paper-container {
 		position: relative;
+		display: flex;
+		justify-content: center;
+		align-items: flex-start;
+		flex-direction: column;
 		background-color: $white;
 		border-radius: $border-radius;
 		box-shadow: $paper-shadow-large;
@@ -35,9 +39,6 @@
 		position: relative;
 		left: -1rem;
 		bottom: -1rem;
-		display: flex;
-		justify-content: center;
-		align-items: flex-start;
 		transform: rotate(var(--rotation));
 		transition:
 			transform 0.3s ease,

--- a/src/components/locations/LocationActionButtons.svelte
+++ b/src/components/locations/LocationActionButtons.svelte
@@ -4,6 +4,7 @@
 	export let text: string;
 	export let variant: 'primary' | 'secondary' = 'primary';
 	export let mobileOnly: boolean = false;
+	export let disabled: boolean = false;
 
 	const dispatch = createEventDispatcher<{
 		click: void;
@@ -19,6 +20,7 @@
 	class:primary={variant === 'primary'}
 	class:secondary={variant === 'secondary'}
 	class:mobile-only={mobileOnly}
+	class:disabled
 	on:click={handleClick}
 >
 	{text}
@@ -55,6 +57,11 @@
 	.action-button.secondary:hover {
 		background: $color_olive;
 		color: white;
+	}
+
+	.action-button.disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
 	}
 
 	.action-button.mobile-only {

--- a/src/components/locations/LocationContexts.svelte
+++ b/src/components/locations/LocationContexts.svelte
@@ -26,6 +26,7 @@
 
 <PaperContainer height="auto" width="66vw" vertical="bottom">
 	<CloseButton onClick={handleClose} />
+	<h4>An dem ausgewählten Standort finden Sie folgende Kontexte:</h4>
 	<div class="location-details-section" transition:slide={{ duration: 150 }}>
 		<!-- Faculties -->
 		{#if availableFaculties.length > 0}
@@ -63,6 +64,10 @@
 </PaperContainer>
 
 <style lang="scss">
+	.location-details-section {
+		margin-top: 1rem;
+	}
+
 	.section-group {
 		margin-bottom: 1.5rem;
 	}

--- a/src/components/locations/LocationContexts.svelte
+++ b/src/components/locations/LocationContexts.svelte
@@ -52,7 +52,7 @@
 						<button
 							class="info-pill clickable-pill"
 							on:click={() => handleContextClick(context.id)}
-							title={getUIText('locations.navigateToOverview', $activeLanguage)}
+							data-tooltip={getUIText('locations.navigateToOverview', $activeLanguage)}
 						>
 							<span class="item-name">{context.name}</span>
 							<span class="project-count">({count})</span>

--- a/src/components/locations/LocationContexts.svelte
+++ b/src/components/locations/LocationContexts.svelte
@@ -26,11 +26,12 @@
 
 <PaperContainer height="auto" width="66vw" vertical="bottom">
 	<CloseButton onClick={handleClose} />
-	<h4>An dem ausgewählten Standort finden Sie folgende Kontexte:</h4>
+	<p class="contexts-heading">{getUIText('locations.contexts.heading', $activeLanguage)}</p>
 	<div class="location-details-section" transition:slide={{ duration: 150 }}>
 		<!-- Faculties -->
 		{#if availableFaculties.length > 0}
 			<div class="section-group">
+				<h4>{getUIText('locations.facultiesHeading', $activeLanguage)}</h4>
 				<div class="pills-container">
 					{#each availableFaculties as { faculty, count }}
 						<div class="info-pill">
@@ -79,6 +80,15 @@
 		margin: 0 0 0.5rem 0;
 		text-transform: uppercase;
 		letter-spacing: 0.5px;
+	}
+
+	.contexts-heading {
+		// font-weight: normal;
+		width: 100%;
+
+		@include desktop {
+			width: 80%;
+		}
 	}
 
 	.clickable-pill {

--- a/src/components/locations/LocationFilters.svelte
+++ b/src/components/locations/LocationFilters.svelte
@@ -157,7 +157,6 @@
 	.location-filter {
 		font-size: 0.9rem;
 		cursor: pointer;
-		padding: 0.25rem 0;
 		transition: color 0.15s ease;
 		color: #333;
 		background: none;

--- a/src/components/locations/LocationFilters.svelte
+++ b/src/components/locations/LocationFilters.svelte
@@ -21,6 +21,7 @@
 	}>;
 	export let allProjects: Project[];
 	export let selectedLocationFilters: string[];
+	export let availableContexts: Array<{ context: EnrichedContextData; count: number }>;
 
 	const dispatch = createEventDispatcher<{
 		locationClick: { locationId: string; event: Event };
@@ -106,6 +107,7 @@
 						<LocationActionButtons
 							text={getUIText('locations.locationActionButtons.showContexts', $activeLanguage)}
 							variant="secondary"
+							disabled={availableContexts.length === 0}
 							on:click={handleToggleContexts}
 						/>
 					</div>

--- a/src/components/locations/LocationFilters.svelte
+++ b/src/components/locations/LocationFilters.svelte
@@ -102,6 +102,7 @@
 						<LocationActionButtons
 							text={getUIText('locations.accordion.showProjects', $activeLanguage)}
 							variant="primary"
+							disabled={allProjects.filter((p) => p.location?.id === item.id).length === 0}
 							on:click={() => handleShowProjects(item.id)}
 						/>
 						<LocationActionButtons

--- a/src/components/locations/MapPopup.svelte
+++ b/src/components/locations/MapPopup.svelte
@@ -25,6 +25,34 @@
 	$: locationProjects = allProjects.filter((p) => p.location?.id === location.id);
 	$: projectCount = locationProjects.length;
 
+	// Extract available contexts for this location
+	$: availableContexts = extractUniqueContexts(locationProjects);
+
+	// Helper function to extract unique contexts from projects
+	function extractUniqueContexts(projects: Project[]): Array<{ context: any; count: number }> {
+		const contextMap = new Map<string, { context: any; count: number }>();
+
+		projects.forEach((project) => {
+			if (project.contexts) {
+				project.contexts.forEach((context) => {
+					const existing = contextMap.get(context.id);
+					if (existing) {
+						existing.count++;
+					} else {
+						contextMap.set(context.id, {
+							context: context,
+							count: 1
+						});
+					}
+				});
+			}
+		});
+
+		return Array.from(contextMap.values()).sort((a, b) =>
+			a.context.name.localeCompare(b.context.name)
+		);
+	}
+
 	function handleShowProjects() {
 		if (projectCount > 0) {
 			onShowProjects(location.id);
@@ -64,11 +92,13 @@
 					count: projectCount
 				})}
 				variant="primary"
+				disabled={projectCount === 0}
 				on:click={handleShowProjects}
 			/>
 			<LocationActionButtons
 				text={getUIText('locations.locationActionButtons.showContexts', $activeLanguage)}
 				variant="secondary"
+				disabled={availableContexts.length === 0}
 				on:click={handleToggleContexts}
 			/>
 		</div>

--- a/src/lib/utils/localization.ts
+++ b/src/lib/utils/localization.ts
@@ -205,6 +205,7 @@ export const UI_TEXTS = {
 		contextsHeading: { de: 'Kontexte', en: 'Contexts' },
 		facultiesHeading: { de: 'Fakultäten', en: 'Faculties' },
 		coursesHeading: { de: 'Kurse', en: 'Courses' },
+		facultiesHeading: { de: 'Fakultäten', en: 'Faculties' },
 		classesHeading: { de: 'Veranstaltungsformen', en: 'Classes' },
 		clearSelection: { de: 'Auswahl löschen', en: 'Clear Selection' },
 		clearContexts: { de: 'Kontexte löschen', en: 'Clear Contexts' },
@@ -242,6 +243,12 @@ export const UI_TEXTS = {
 			showOnMap: { de: 'Auf Karte zeigen', en: 'Show on Map' },
 			showProjects: { de: 'Projekte zeigen', en: 'Show Projects' },
 			showContexts: { de: 'Kontexte zeigen', en: 'Show Contexts' }
+		},
+		contexts: {
+			heading: {
+				de: 'An dem ausgewählten Standort finden Projekte im Rahmen folgender Kontexte statt:',
+				en: 'Projects at the selected location take place in the following contexts:'
+			}
 		}
 	},
 

--- a/src/main.css
+++ b/src/main.css
@@ -207,13 +207,14 @@ input[type='checkbox'] {
 [data-tooltip]::after {
 	display: block;
 	position: absolute;
+	color: black;
 	content: attr(data-tooltip);
 	border: 1px solid black;
-	border-radius: 0.25em;
-	font-size: 0.8em;
+	border-radius: 0.5rem;
+	font-size: 0.8rem;
 	line-height: 1.2;
 	background: white;
-	padding: 0.25em 0.5ch 0.1em;
+	padding: 0.5em 1.5ch 0.3em;
 	transform: translateX(-50%) rotate(1.5deg);
 	z-index: 500;
 	pointer-events: none;

--- a/src/routes/locations/+page.svelte
+++ b/src/routes/locations/+page.svelte
@@ -48,6 +48,9 @@
 	// Context visibility toggle state
 	let showContexts = false;
 
+	// Loading state for contexts computation
+	let availableContexts: Array<{ context: EnrichedContextData; count: number }> = [];
+
 	// Get selected location filters from filter store
 	$: selectedLocationFilters = $filterStore.selectedFilters.locations || [];
 
@@ -253,6 +256,7 @@
 				{locations}
 				{allProjects}
 				{selectedLocationFilters}
+				{availableContexts}
 				on:locationClick={({ detail }) => handleLocationClick(detail.locationId, detail.event)}
 				on:showOnMap={({ detail }) => handleShowOnMap(detail.locationId, detail.event)}
 				on:showProjects={({ detail }) => handleShowProjects(detail.locationId)}
@@ -260,7 +264,7 @@
 				on:toggleContexts={handleToggleContexts}
 			/>
 			<!-- Location Contexts -->
-			{#if showContexts && selectedLocationFilters.length > 0}
+			{#if showContexts && availableContexts.length > 0 && selectedLocationFilters.length > 0}
 				<LocationContexts
 					{availableFaculties}
 					{availableContexts}
@@ -318,7 +322,6 @@
 		position: relative;
 	}
 
-
 	.filter-container {
 		flex: 0 0 20vw;
 		height: 100%;
@@ -347,7 +350,6 @@
 			}
 		}
 	}
-
 
 	/* Projects Sidebar */
 	:global(.overlay-content) {
@@ -435,6 +437,5 @@
 		max-width: 90vw;
 		max-height: 90vh;
 		overflow-y: auto;
-
 	}
 </style>


### PR DESCRIPTION
The contexts overlay for each location on `/locations` now don't open, if they are empty, i.e. no contexts available. In that case, the `LocationActionButton` now has a state `disabled`. 
Also, a one paragraph explanatory text was added.