### PR TITLE
scroll to top on filter select

### DIFF
--- a/src/components/general/ProjectContainer.svelte
+++ b/src/components/general/ProjectContainer.svelte
@@ -14,6 +14,7 @@
 
 	let width = $state(0);
 	let height = $state(0);
+	let masonryContainer: HTMLDivElement;
 
 	// Accept projects as a prop
 	const {
@@ -61,6 +62,7 @@
 				// Filter changed - apply new filter and shuffle
 				currentFilterKey = key;
 				const shuffled = shuffleOnce(newList);
+				scrollToTop();
 				return shuffled;
 			}
 
@@ -85,6 +87,12 @@
 			[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
 		}
 		return shuffled;
+	}
+
+	function scrollToTop() {
+		if (masonryContainer) {
+			masonryContainer.scrollIntoView({ behavior: 'smooth', block: 'start' });
+		}
 	}
 
 	function seededChance(id: string): number {
@@ -157,6 +165,7 @@
 </script>
 
 <div
+	bind:this={masonryContainer}
 	class="masonry-container"
 	class:half-width={variant === 'half'}
 	class:bottom-space={bottomSpace}


### PR DESCRIPTION
before, the selection of a filter left the user at the same scroll position, meaning that since some projects above disappeared, there was likely some items that the viewer had not yet seen scrolling down. this is inconvenient.

when a filter is selected, now a scroll to the top of `.masonry-container` is triggered.