### PR TITLE
18 removed images still displayed

### DIFF
--- a/src/components/general/ProjectSingle.svelte
+++ b/src/components/general/ProjectSingle.svelte
@@ -21,8 +21,8 @@
 	// Get optimal title image
 	let titleImage = $derived.by(() => {
 		if (!project?.titleImage?.[0]) {
-			// Fallback to first image if no titleImage
-			return project?.images?.[0] || null;
+			// Do not fallback to project.images[0] because it contains also images that should no longer be shown at all
+			return null;
 		}
 		return project.titleImage[0];
 	});


### PR DESCRIPTION
before, all images from `project.images` were shown, which also contains images that were added and then removed from the `content` of a project. now we only show images that are in `content`.

also removed the fallback to pick the first entry from `project.images` as `title_image` if that is not defined. because it uses `project.images` instead of `content`, it potentially also used images that have been removed, which is hard to understand for the user.

see #18 