### PR TITLE
22 faculty filter

### DIFF
--- a/src/components/filter/Filter.svelte
+++ b/src/components/filter/Filter.svelte
@@ -54,7 +54,7 @@
 >
 	<div class="content">
 		<div class="header">
-			<h1>{getUIText('filter.title', $activeLanguage)}</h1>
+			<h3 class="filter-title">{getUIText('filter.title', $activeLanguage)}</h3>
 			{#if hasActiveFilters}
 				<button class="clear-all-button" on:click={clearAllFilters}>
 					{getUIText('filter.clearSelection', $activeLanguage) || 'Clear all'}
@@ -70,7 +70,7 @@
 			<!-- Regular filters for other pages -->
 			<div class="filter-options">
 				{#each filteredGroups as group}
-					<div class="filter-group">
+					<div class="filter-group {group.title.toLowerCase()}">
 						<h3>{group.title}</h3>
 						{#each group.options as option}
 							{#if option.projectCount && option.projectCount > 0}
@@ -110,7 +110,7 @@
 		margin: 0 0 1.5rem 0;
 	}
 
-	h1 {
+	.filter-title {
 		margin: 0;
 		font-size: $font-xlarge;
 		font-weight: 400;
@@ -147,6 +147,10 @@
 		display: flex;
 		flex-direction: column;
 		gap: 1.75rem;
+	}
+
+	:global(.filter-group.formats) span {
+		text-transform: capitalize;
 	}
 
 	:global(.filter-group) {

--- a/src/components/filter/Filter.svelte
+++ b/src/components/filter/Filter.svelte
@@ -17,7 +17,9 @@
 	}
 
 	function handleFilterChange(category: string, value: string) {
-		toggleFilterOption(category, value);
+		// Store faculty selections under 'contexts' since faculties are a type of context
+		const filterCategory = category === 'faculties' ? 'contexts' : category;
+		toggleFilterOption(filterCategory, value);
 	}
 
 	function clearAllFilters() {
@@ -27,7 +29,9 @@
 	}
 
 	function isOptionSelected(category: string, value: string): boolean {
-		return $filterStore.selectedFilters[category]?.includes(value) || false;
+		// Check faculty selections under 'contexts' since that's where we store them
+		const filterCategory = category === 'faculties' ? 'contexts' : category;
+		return $filterStore.selectedFilters[filterCategory]?.includes(value) || false;
 	}
 
 	$: hasActiveFilters = Object.values($filterStore.selectedFilters).some(

--- a/src/components/filter/Filter.svelte
+++ b/src/components/filter/Filter.svelte
@@ -153,6 +153,10 @@
 		text-transform: capitalize;
 	}
 
+	:global(.filter-group.faculties) .filter-count {
+		display: none;
+	}
+
 	:global(.filter-group) {
 		display: flex;
 		flex-direction: column;

--- a/src/components/general/ProjectContainer.svelte
+++ b/src/components/general/ProjectContainer.svelte
@@ -7,7 +7,9 @@
 	import { activeLanguage } from '$lib/stores/language';
 	import { filterProjects } from '$lib/utils';
 	import type { Project } from '$lib/api/types/index';
+	import type { ContextsResponse } from '$lib/api/types/index';
 	import { projectsService } from '$lib/api';
+	import { filtersService } from '$lib/api/services/filters';
 
 	import { writable, derived, get } from 'svelte/store';
 	import Masonry from 'svelte-bricks';
@@ -36,6 +38,9 @@
 	// Initialize the projects store with the prop value
 	const projectsStore = writable<Project[]>(projects);
 
+	// Store for contexts data used in hierarchical filtering
+	const contextsDataStore = writable<ContextsResponse | null>(null);
+
 	// Update projects when prop changes
 	$effect(() => {
 		// Always update the store when projects prop changes, regardless of length
@@ -43,13 +48,31 @@
 		projectsStore.set(projects);
 	});
 
-	const rawFiltered = derived([projectsStore, filterStore], ([$projects, $filterStore]) => {
-		// Skip filtering if disabled (e.g., on timeline page where filtering is handled by parent)
-		if (disableFiltering) {
-			return $projects;
+	// Load contexts data for hierarchical filtering
+	$effect(() => {
+		if (!disableFiltering) {
+			filtersService
+				.getRawContexts()
+				.then((data) => {
+					contextsDataStore.set(data);
+				})
+				.catch((error) => {
+					console.error('Failed to load contexts data for filtering:', error);
+					contextsDataStore.set(null);
+				});
 		}
-		return filterProjects($projects, $filterStore.selectedFilters);
 	});
+
+	const rawFiltered = derived(
+		[projectsStore, filterStore, contextsDataStore],
+		([$projects, $filterStore, $contextsData]) => {
+			// Skip filtering if disabled (e.g., on timeline page where filtering is handled by parent)
+			if (disableFiltering) {
+				return $projects;
+			}
+			return filterProjects($projects, $filterStore.selectedFilters, $contextsData);
+		}
+	);
 
 	const filteredProjects = writable<Project[]>([]);
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,5 @@
 import type { Project } from './api/types/projects';
 import type { EnrichedFormatData, EnrichedContextData } from './api/types/kirby';
-import type { ContextsResponse } from './api/types/filters';
 import { locationMatchData } from './data/locations';
 
 /**
@@ -23,38 +22,6 @@ export function getRandomNumber(min: number, max: number): number {
 	return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
-
-/**
- * Create a lookup map from context ID to all its parent faculty IDs
- * @param contextsData The raw contexts data from the API
- * @returns Map from context ID to array of parent faculty IDs
- */
-function createContextToFacultyMap(contextsData: ContextsResponse | null): Map<string, string[]> {
-	const map = new Map<string, string[]>();
-
-	if (!contextsData?.faculties) return map;
-
-	contextsData.faculties.forEach((faculty) => {
-		const facultyIds = [faculty.id];
-
-		// Add faculty itself
-		map.set(faculty.id, facultyIds);
-
-		// Add all child contexts
-		faculty.institutes?.forEach((institute) => {
-			map.set(institute.id, facultyIds);
-			institute.courses?.forEach((course) => {
-				map.set(course.id, facultyIds);
-				course.classes?.forEach((classItem) => {
-					map.set(classItem.id, facultyIds);
-				});
-			});
-		});
-	});
-
-	return map;
-}
-
 /**
  * Append a log entry to app.log in the project root
  * @param input The input to log (any type)
@@ -65,23 +32,16 @@ function createContextToFacultyMap(contextsData: ContextsResponse | null): Map<s
  * Filter projects based on selected filter criteria
  * @param projects Array of projects to filter
  * @param selectedFilters Object mapping filter categories to selected values
- * @param contextsData Optional raw contexts data for hierarchical filtering
  * @returns Filtered array of projects
  */
 export function filterProjects(
 	projects: Project[],
-	selectedFilters: Record<string, string[]>,
-	contextsData?: ContextsResponse | null
+	selectedFilters: Record<string, string[]>
 ): Project[] {
-	// Create context-to-faculty map for hierarchical filtering
-	const contextToFacultyMap = createContextToFacultyMap(contextsData || null);
-
 	return projects.filter((project) => {
 		// Check formats filter (maps to project.formats)
 		if (selectedFilters.formats && selectedFilters.formats.length > 0) {
 			const hasMatchingFormat = selectedFilters.formats.some((selectedFormat) => {
-				console.log('selectedFormat', selectedFormat);
-				console.log('project.formats', project.formats);
 				return project.formats.some((format: EnrichedFormatData) => format.key === selectedFormat);
 			});
 			if (!hasMatchingFormat) return false;
@@ -102,28 +62,16 @@ export function filterProjects(
 			if (!hasMatchingLocation) return false;
 		}
 
-		// Check contexts filter (maps to project.contexts) - with hierarchical support
+		// Check contexts filter - use same logic as server-side count calculation
 		if (selectedFilters.contexts && selectedFilters.contexts.length > 0) {
+			// Extract raw category IDs from enriched contexts (same as server-side categories field)
+			const projectCategoryIds = project.contexts.map((context) => context.id);
+
+			// Check if any selected context ID is in the project's category IDs
 			const hasMatchingContext = selectedFilters.contexts.some((selectedContext) => {
-				// Check if any of the project's contexts match the selected context directly
-				const directMatch = project.contexts.some(
-					(context: EnrichedContextData) => context.id === selectedContext
-				);
-
-				if (directMatch) return true;
-
-				// Check for hierarchical match (if a faculty is selected, include projects from its child contexts)
-				if (contextsData && contextToFacultyMap.size > 0) {
-					return project.contexts.some((context: EnrichedContextData) => {
-						// Get all parent faculties for this context
-						const parentFaculties = contextToFacultyMap.get(context.id) || [];
-						// Check if any parent faculty matches the selected context
-						return parentFaculties.includes(selectedContext);
-					});
-				}
-
-				return false;
+				return projectCategoryIds.includes(selectedContext);
 			});
+
 			if (!hasMatchingContext) return false;
 		}
 


### PR DESCRIPTION
Fixes #22 
`faculty` is not a top-level property of a project, such as e.g. `location`, but nested in `contexts`. Therefore, the filter logic is more complex.

Note: The filter count is showing incorrect numbers. I unsuccessfully tried to fix, but decided then that it is not the most urgent issue. Therefore the counts for `faculties` are hidden now.