### PR TITLE
use grup key instead of name for filters to allow for localization

### DIFF
--- a/src/components/filter/Filter.svelte
+++ b/src/components/filter/Filter.svelte
@@ -116,15 +116,15 @@
 			<!-- Regular filters for other pages -->
 			<div class="filter-options">
 				{#each filteredGroups as group}
-					<div class="filter-group {group.title.toLowerCase()}">
+					<div class="filter-group {group.key}">
 						<h3>{group.title}</h3>
 						{#each group.options as option}
 							{#if option.projectCount && option.projectCount > 0}
-								<label class:selected={isOptionSelected(group.title.toLowerCase(), option.value)}>
+								<label class:selected={isOptionSelected(group.key, option.value)}>
 									<input
 										type="checkbox"
-										checked={isOptionSelected(group.title.toLowerCase(), option.value)}
-										on:change={() => handleFilterChange(group.title.toLowerCase(), option.value)}
+										checked={isOptionSelected(group.key, option.value)}
+										on:change={() => handleFilterChange(group.key, option.value)}
 									/>
 									<span class="filter-text">{option.label}</span>
 									<span class="dots"></span>

--- a/src/lib/api/transformers/filters.ts
+++ b/src/lib/api/transformers/filters.ts
@@ -99,6 +99,7 @@ export function transformContexts(data: ContextsResponse): FilterGroup[] {
 		? [
 				{
 					title: 'Faculties',
+					key: 'faculties',
 					options: facultyOptions
 				}
 			]
@@ -133,6 +134,7 @@ export function transformLocations(data: LocationsResponse): FilterGroup[] {
 		? [
 				{
 					title: 'Locations',
+					key: 'locations',
 					options
 				}
 			]
@@ -173,6 +175,7 @@ export function transformFormats(data: FormatsResponse): FilterGroup[] {
 		? [
 				{
 					title: 'Formats',
+					key: 'formats',
 					options
 				}
 			]

--- a/src/lib/api/types/common.ts
+++ b/src/lib/api/types/common.ts
@@ -45,6 +45,7 @@ export interface FilterOption {
 
 export interface FilterGroup {
 	title: string;
+	key: string;
 	options: FilterOption[];
 }
 


### PR DESCRIPTION
- otherwise the localized versions, e.g. `fakultäten` were used in the German version, which was causing the filter to fail.